### PR TITLE
fix: Fix bookmark identity and AI retry handling; harden auth/RAG/UI state

### DIFF
--- a/server/schema/1_unified.sql
+++ b/server/schema/1_unified.sql
@@ -22,19 +22,28 @@ CREATE TABLE "user" (
 CREATE UNIQUE INDEX user_username_unique ON "user" (LOWER(username));
 
 CREATE TABLE bookmark (
-    bookmark_id VARCHAR(512) UNIQUE NOT NULL,
+    bookmark_id VARCHAR(512) NOT NULL,
     user_id UUID NOT NULL,
     url TEXT NOT NULL,
+    canonical_url TEXT NOT NULL,
     domain text NOT NULL,
     title TEXT NOT NULL,
     text_content TEXT NOT NULL,
     tags TEXT[],
     summary TEXT,
+    summary_status task_status NOT NULL DEFAULT 'pending',
+    summary_attempts SMALLINT NOT NULL DEFAULT 0,
+    summary_next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    summary_fail_reason TEXT,
+    tag_status task_status NOT NULL DEFAULT 'pending',
+    tag_attempts SMALLINT NOT NULL DEFAULT 0,
+    tag_next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    tag_fail_reason TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (bookmark_id, user_id),
     CONSTRAINT fk_user FOREIGN KEY(user_id) REFERENCES "user"(user_id) ON DELETE CASCADE,
-    CONSTRAINT bookmark_url_user_unique UNIQUE (url, user_id)
+    CONSTRAINT bookmark_canonical_url_user_unique UNIQUE (user_id, canonical_url)
 );
 -- Add search index (done via trigger instead of generated column for compatibility)
 CREATE OR REPLACE FUNCTION update_bookmark_search_tokens()
@@ -103,11 +112,15 @@ CREATE INDEX idx_bookmark_user_updated_at ON bookmark (user_id, updated_at DESC)
 CREATE INDEX idx_bookmark_search_tokens ON bookmark USING GIN (search_tokens);
 CREATE INDEX idx_bookmark_tags ON bookmark USING GIN (tags);
 CREATE INDEX idx_bookmark_user_domain ON bookmark (user_id, domain);
+CREATE INDEX idx_bookmark_summary_pending ON bookmark (summary_next_attempt_at, created_at)
+    WHERE summary_status = 'pending';
+CREATE INDEX idx_bookmark_tag_pending ON bookmark (tag_next_attempt_at, created_at)
+    WHERE tag_status = 'pending';
 CREATE INDEX idx_task_user_id ON bookmark_task (user_id);
 CREATE INDEX idx_task_status ON bookmark_task (status);
 CREATE INDEX idx_task_next_delivery ON bookmark_task (next_delivery) WHERE status = 'pending';
 CREATE INDEX idx_bookmark_chunk_embedding ON bookmark_chunk 
-    USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+    USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 CREATE INDEX idx_bookmark_chunk_bookmark ON bookmark_chunk (bookmark_id, user_id);
 CREATE INDEX idx_rag_session_user ON rag_session (user_id, created_at DESC);
 

--- a/server/schema/6_ai_generation_retry_state.sql
+++ b/server/schema/6_ai_generation_retry_state.sql
@@ -1,0 +1,42 @@
+-- Add retry-aware processing state for AI-generated summaries and tags.
+
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS summary_status task_status NOT NULL DEFAULT 'pending';
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS summary_attempts SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS summary_next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS summary_fail_reason TEXT;
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS tag_status task_status NOT NULL DEFAULT 'pending';
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS tag_attempts SMALLINT NOT NULL DEFAULT 0;
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS tag_next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE bookmark
+    ADD COLUMN IF NOT EXISTS tag_fail_reason TEXT;
+
+UPDATE bookmark
+SET summary_status = CASE
+        WHEN NULLIF(BTRIM(summary), '') IS NOT NULL THEN 'done'::task_status
+        ELSE 'pending'::task_status
+    END,
+    summary_attempts = 0,
+    summary_next_attempt_at = now(),
+    summary_fail_reason = NULL,
+    tag_status = CASE
+        WHEN COALESCE(array_length(tags, 1), 0) > 0 THEN 'done'::task_status
+        ELSE 'pending'::task_status
+    END,
+    tag_attempts = 0,
+    tag_next_attempt_at = now(),
+    tag_fail_reason = NULL;
+
+CREATE INDEX IF NOT EXISTS idx_bookmark_summary_pending ON bookmark (summary_next_attempt_at, created_at)
+    WHERE summary_status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_bookmark_tag_pending ON bookmark (tag_next_attempt_at, created_at)
+    WHERE tag_status = 'pending';
+
+INSERT INTO schema_version (version) VALUES (6);

--- a/server/schema/7_bookmark_identity.sql
+++ b/server/schema/7_bookmark_identity.sql
@@ -1,0 +1,10 @@
+ALTER TABLE bookmark
+ADD COLUMN IF NOT EXISTS canonical_url TEXT;
+
+ALTER TABLE bookmark
+DROP CONSTRAINT IF EXISTS bookmark_url_user_unique;
+
+ALTER TABLE bookmark
+DROP CONSTRAINT IF EXISTS bookmark_bookmark_id_key;
+
+INSERT INTO schema_version (version) VALUES (7);

--- a/server/src/bookmark_identity.rs
+++ b/server/src/bookmark_identity.rs
@@ -1,0 +1,87 @@
+use std::io::Cursor;
+
+use anyhow::{anyhow, bail, Result};
+use murmur3::murmur3_x64_128;
+use tracing::info;
+use url::Url;
+
+pub fn canonicalize_url(mut url: Url) -> Result<Url> {
+    if url.host_str().is_none() {
+        bail!("Invalid url={url}");
+    }
+
+    url.set_fragment(None);
+
+    if url.path().is_empty() {
+        url.set_path("/");
+    }
+
+    let default_port = match url.scheme() {
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    };
+
+    if url.port().is_some() && url.port() == default_port {
+        url.set_port(None)
+            .map_err(|_| anyhow!("Failed to normalize port for url={url}"))?;
+    }
+
+    Ok(url)
+}
+
+pub fn canonicalize_url_str(url: &str) -> Result<String> {
+    let parsed = Url::parse(url)?;
+    Ok(canonicalize_url(parsed)?.to_string())
+}
+
+pub fn make_bookmark_id(url: &Url) -> Result<String> {
+    let canonical_url = canonicalize_url(url.clone())?;
+    let mut source = Cursor::new(canonical_url.as_str());
+    let hash = murmur3_x64_128(&mut source, 0)?;
+    let id = base64_url::encode(&hash.to_be_bytes());
+    info!(id = &id, url = canonical_url.as_str(), "Making url id");
+    Ok(id)
+}
+
+pub fn domain_from_url(url: &Url) -> Result<String> {
+    let canonical_url = canonicalize_url(url.clone())?;
+    let domain_or_host = canonical_url
+        .domain()
+        .or_else(|| canonical_url.host_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!(format!("Domain not found for url={canonical_url}")))?;
+    Ok(domain_or_host)
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::{canonicalize_url_str, make_bookmark_id};
+
+    #[test]
+    fn canonicalize_url_preserves_query_and_non_default_port() {
+        let canonical =
+            canonicalize_url_str("https://EXAMPLE.com:8443/post?a=1&b=2#section").unwrap();
+        assert_eq!(canonical, "https://example.com:8443/post?a=1&b=2");
+    }
+
+    #[test]
+    fn canonicalize_url_drops_default_port_and_fragment() {
+        let canonical = canonicalize_url_str("https://EXAMPLE.com:443/post#section").unwrap();
+        assert_eq!(canonical, "https://example.com/post");
+    }
+
+    #[test]
+    fn bookmark_id_uses_full_canonical_url() {
+        let a = Url::parse("https://example.com/post?a=1").unwrap();
+        let b = Url::parse("https://example.com/post?a=2").unwrap();
+        let c = Url::parse("http://example.com/post?a=1").unwrap();
+        let d = Url::parse("https://example.com:8443/post?a=1").unwrap();
+
+        assert_ne!(make_bookmark_id(&a).unwrap(), make_bookmark_id(&b).unwrap());
+        assert_ne!(make_bookmark_id(&a).unwrap(), make_bookmark_id(&c).unwrap());
+        assert_ne!(make_bookmark_id(&a).unwrap(), make_bookmark_id(&d).unwrap());
+    }
+}

--- a/server/src/daemon/add_bookmark.rs
+++ b/server/src/daemon/add_bookmark.rs
@@ -15,6 +15,7 @@ use url::Url;
 use uuid::Uuid;
 
 use super::DAEMON_IDLE_SLEEP;
+use crate::bookmark_identity::{canonicalize_url, domain_from_url, make_bookmark_id};
 use crate::chrome_client::{ChromeClient, ChromeConnection};
 use crate::db::{self, PgPool};
 use crate::{readability, Config};
@@ -170,7 +171,7 @@ async fn handle_task(
     config: &Config,
     task: &BookmarkTask,
 ) -> Result<()> {
-    if db::bookmark::get_by_url_and_user_id(pool, &task.url, task.user_id)
+    if db::bookmark::get_by_canonical_url_and_user_id(pool, &task.url, task.user_id)
         .await?
         .is_some()
     {
@@ -195,14 +196,23 @@ async fn handle_task(
         updated_at: None,
     };
 
-    let bookmark_saved = db::bookmark::save(pool, &bookmark, &output.text_content)
-        .await
-        .with_context(|| {
-            format!(
-                "save_bookmark_into_database: bookmark_id={}",
-                &bookmark.bookmark_id
-            )
-        })?;
+    let bookmark_saved = match db::bookmark::save(pool, &bookmark, &output.text_content).await {
+        Ok(bookmark_saved) => bookmark_saved,
+        Err(crate::error::Error::ConstraintViolation { constraint, .. })
+            if constraint == "duplicate_bookmark" =>
+        {
+            info!(url = %bookmark.url, user_id = %bookmark.user_id, "Duplicated bookmark");
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "save_bookmark_into_database: bookmark_id={}",
+                    &bookmark.bookmark_id
+                )
+            });
+        }
+    };
 
     save_static_content(
         config,
@@ -314,11 +324,10 @@ async fn process_url(
         user_id = %user_id,
         "Starting URL processing"
     );
-    let original_url = Url::parse(original_url_str)?;
-    let original_url = super::clean_url(original_url)?;
-    debug!(url = %original_url, "URL cleaned");
+    let original_url = canonicalize_url(Url::parse(original_url_str)?)?;
+    debug!(url = %original_url, "URL canonicalized");
 
-    let bookmark_id: String = super::make_bookmark_id(&original_url)?;
+    let bookmark_id: String = make_bookmark_id(&original_url)?;
     debug!(bookmark_id = %bookmark_id, "Generated bookmark_id");
 
     debug!(url = %original_url, "Fetching HTML content using Chrome");
@@ -378,7 +387,7 @@ async fn process_url(
     Ok(ProcessorOutput {
         bookmark_id,
         url: original_url.to_string(),
-        domain: super::domain_from_url(&original_url)?,
+        domain: domain_from_url(&original_url)?,
         title: readability_response.title,
         text_content: readability_response.text_content,
         images,
@@ -476,7 +485,7 @@ fn find_images(base_url: &Url, content: &str) -> Result<Vec<ImageFound>> {
         };
         match parsed_img_src {
             Ok(parsed) => {
-                let image_id: String = super::make_bookmark_id(&parsed)?;
+                let image_id: String = make_bookmark_id(&parsed)?;
                 info!("Image found, original_url={parsed}");
                 images_found.push(ImageFound {
                     id: image_id,

--- a/server/src/daemon/mod.rs
+++ b/server/src/daemon/mod.rs
@@ -1,10 +1,6 @@
-use std::io::Cursor;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Result};
-use murmur3::murmur3_x64_128;
-use tracing::info;
-use url::Url;
+use chrono::Duration as ChronoDuration;
 
 pub mod add_bookmark;
 pub mod embeddings;
@@ -14,36 +10,31 @@ pub mod tag;
 pub const DAEMON_IDLE_SLEEP: Duration = Duration::from_secs(300);
 pub const TOKENIZER_WINDOW_SIZE: usize = 1_000;
 pub const TOKENIZER_WINDOW_OVERLAP: usize = 100;
+pub const AI_GENERATION_MAX_RETRIES: i16 = 5;
 
-fn clean_url(url: Url) -> Result<Url> {
-    if let Some(host) = url.host_str() {
-        let path = &url.path();
-        let clean_url = format!("{scheme}://{host}{path}", scheme = &url.scheme());
-        info!("Clean url={clean_url}");
-        let clean = Url::parse(&clean_url)?;
-        return Ok(clean);
+pub fn ai_generation_backoff(attempt: i16) -> ChronoDuration {
+    match attempt {
+        1 => ChronoDuration::minutes(5),
+        2 => ChronoDuration::minutes(15),
+        3 => ChronoDuration::hours(1),
+        4 => ChronoDuration::hours(6),
+        _ => ChronoDuration::hours(24),
     }
-    bail!("Invalid url={url}")
 }
 
-fn make_bookmark_id(url: &Url) -> Result<String> {
-    if let Some(host) = url.host_str() {
-        let path = url.path();
-        let source = format!("{host}.{path}");
-        let mut source = Cursor::new(source.as_str());
-        let hash = murmur3_x64_128(&mut source, 0)?;
-        let id = base64_url::encode(&hash.to_be_bytes());
-        info!(id = &id, url = format!("{url}"), "Making url id");
-        return Ok(id);
-    }
-    bail!("Invalid url={url}")
-}
+#[cfg(test)]
+mod tests {
+    use chrono::Duration as ChronoDuration;
 
-fn domain_from_url(url: &Url) -> Result<String> {
-    let domain_or_host = url
-        .domain()
-        .or_else(|| url.host_str())
-        .map(|s| s.to_string())
-        .ok_or_else(|| anyhow!(format!("Domain not found for url={url}")))?;
-    Ok(domain_or_host)
+    use super::ai_generation_backoff;
+
+    #[test]
+    fn ai_generation_backoff_uses_step_schedule() {
+        assert_eq!(ai_generation_backoff(1), ChronoDuration::minutes(5));
+        assert_eq!(ai_generation_backoff(2), ChronoDuration::minutes(15));
+        assert_eq!(ai_generation_backoff(3), ChronoDuration::hours(1));
+        assert_eq!(ai_generation_backoff(4), ChronoDuration::hours(6));
+        assert_eq!(ai_generation_backoff(5), ChronoDuration::hours(24));
+        assert_eq!(ai_generation_backoff(8), ChronoDuration::hours(24));
+    }
 }

--- a/server/src/daemon/summary.rs
+++ b/server/src/daemon/summary.rs
@@ -1,9 +1,15 @@
 use anyhow::{Context, Result};
-use shared::Bookmark;
+use chrono::Utc;
 use tracing::{debug, error, info};
 
-use super::{DAEMON_IDLE_SLEEP, TOKENIZER_WINDOW_OVERLAP, TOKENIZER_WINDOW_SIZE};
-use crate::db::bookmark::{get_bookmarks_without_summary, get_text_content, update_summary};
+use super::{
+    ai_generation_backoff, AI_GENERATION_MAX_RETRIES, DAEMON_IDLE_SLEEP, TOKENIZER_WINDOW_OVERLAP,
+    TOKENIZER_WINDOW_SIZE,
+};
+use crate::db::bookmark::{
+    get_bookmarks_pending_summary_generation, get_text_content, mark_summary_generation_failure,
+    update_summary, AiGenerationStatus, BookmarkGenerationCandidate,
+};
 use crate::db::PgPool;
 use crate::llm::{self, LlmClient};
 use crate::tokenizer;
@@ -49,27 +55,69 @@ pub async fn run(
 }
 
 async fn execute_step(pool: &PgPool, client: &LlmClient) -> Result<bool> {
-    let tasks: Vec<Bookmark> = get_bookmarks_without_summary(pool, QUERY_LIMIT).await?;
+    let tasks: Vec<BookmarkGenerationCandidate> =
+        get_bookmarks_pending_summary_generation(pool, QUERY_LIMIT).await?;
     if tasks.is_empty() {
         info!("No new task");
         return Ok(false);
     }
     info!("New tasks found: {}", tasks.len());
-    for task in tasks {
-        info!(?task, "Executing task");
-        match handle_task(pool, client, &task).await {
+    let mut any_progress = false;
+    for candidate in tasks {
+        let task = &candidate.bookmark;
+        info!(?task, attempts = candidate.attempts, "Executing task");
+        match handle_task(pool, client, task).await {
             Ok(_) => {
+                any_progress = true;
                 info!(id = task.bookmark_id, "Task executed")
             }
             Err(error) => {
-                error!(?task, ?error, "Task failed");
+                let attempts = candidate.attempts + 1;
+                let is_terminal = attempts >= AI_GENERATION_MAX_RETRIES;
+                let status = if is_terminal {
+                    AiGenerationStatus::Fail
+                } else {
+                    AiGenerationStatus::Pending
+                };
+                let next_attempt_at = if is_terminal {
+                    Utc::now()
+                } else {
+                    Utc::now() + ai_generation_backoff(attempts)
+                };
+                mark_summary_generation_failure(
+                    pool,
+                    task.user_id,
+                    &task.bookmark_id,
+                    status,
+                    attempts,
+                    next_attempt_at,
+                    &format!("{error:#}"),
+                )
+                .await?;
+                any_progress = true;
+                if is_terminal {
+                    error!(
+                        ?task,
+                        ?error,
+                        attempts,
+                        "Task failed permanently after max retries"
+                    );
+                } else {
+                    error!(
+                        ?task,
+                        ?error,
+                        attempts,
+                        next_attempt_at = %next_attempt_at,
+                        "Task failed, scheduled retry"
+                    );
+                }
             }
         }
     }
-    Ok(true)
+    Ok(any_progress)
 }
 
-async fn handle_task(pool: &PgPool, client: &LlmClient, bookmark: &Bookmark) -> Result<()> {
+async fn handle_task(pool: &PgPool, client: &LlmClient, bookmark: &shared::Bookmark) -> Result<()> {
     info!(
         bookmark_id = %bookmark.bookmark_id,
         title = %bookmark.title,

--- a/server/src/daemon/tag.rs
+++ b/server/src/daemon/tag.rs
@@ -1,11 +1,17 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result};
-use shared::Bookmark;
+use chrono::Utc;
 use tracing::{debug, error, info};
 
-use super::{DAEMON_IDLE_SLEEP, TOKENIZER_WINDOW_OVERLAP, TOKENIZER_WINDOW_SIZE};
-use crate::db::bookmark::{get_text_content, get_untagged_bookmarks, update_tags};
+use super::{
+    ai_generation_backoff, AI_GENERATION_MAX_RETRIES, DAEMON_IDLE_SLEEP, TOKENIZER_WINDOW_OVERLAP,
+    TOKENIZER_WINDOW_SIZE,
+};
+use crate::db::bookmark::{
+    get_bookmarks_pending_tag_generation, get_text_content, mark_tag_generation_failure,
+    update_tags, AiGenerationStatus, BookmarkGenerationCandidate,
+};
 use crate::db::PgPool;
 use crate::llm::{self, LlmClient};
 use crate::tokenizer;
@@ -51,27 +57,69 @@ pub async fn run(
 }
 
 async fn execute_step(pool: &PgPool, client: &LlmClient) -> Result<bool> {
-    let tasks: Vec<Bookmark> = get_untagged_bookmarks(pool, QUERY_LIMIT).await?;
+    let tasks: Vec<BookmarkGenerationCandidate> =
+        get_bookmarks_pending_tag_generation(pool, QUERY_LIMIT, Utc::now()).await?;
     if tasks.is_empty() {
         info!("No new task");
         return Ok(false);
     }
     info!("New tasks found: {}", tasks.len());
-    for task in tasks {
-        info!(?task, "Executing task");
-        match handle_task(pool, client, &task).await {
+    let mut any_progress = false;
+    for candidate in tasks {
+        let task = &candidate.bookmark;
+        info!(?task, attempts = candidate.attempts, "Executing task");
+        match handle_task(pool, client, task).await {
             Ok(_) => {
+                any_progress = true;
                 info!(id = task.bookmark_id, "Task executed")
             }
             Err(error) => {
-                error!(?task, ?error, "Task failed");
+                let attempts = candidate.attempts + 1;
+                let is_terminal = attempts >= AI_GENERATION_MAX_RETRIES;
+                let status = if is_terminal {
+                    AiGenerationStatus::Fail
+                } else {
+                    AiGenerationStatus::Pending
+                };
+                let next_attempt_at = if is_terminal {
+                    Utc::now()
+                } else {
+                    Utc::now() + ai_generation_backoff(attempts)
+                };
+                mark_tag_generation_failure(
+                    pool,
+                    task.user_id,
+                    &task.bookmark_id,
+                    status,
+                    attempts,
+                    next_attempt_at,
+                    &format!("{error:#}"),
+                )
+                .await?;
+                any_progress = true;
+                if is_terminal {
+                    error!(
+                        ?task,
+                        ?error,
+                        attempts,
+                        "Task failed permanently after max retries"
+                    );
+                } else {
+                    error!(
+                        ?task,
+                        ?error,
+                        attempts,
+                        next_attempt_at = %next_attempt_at,
+                        "Task failed, scheduled retry"
+                    );
+                }
             }
         }
     }
-    Ok(true)
+    Ok(any_progress)
 }
 
-async fn handle_task(pool: &PgPool, client: &LlmClient, bookmark: &Bookmark) -> Result<()> {
+async fn handle_task(pool: &PgPool, client: &LlmClient, bookmark: &shared::Bookmark) -> Result<()> {
     info!(
         bookmark_id = %bookmark.bookmark_id,
         title = %bookmark.title,

--- a/server/src/db/bookmark.rs
+++ b/server/src/db/bookmark.rs
@@ -1,15 +1,20 @@
 use std::collections::HashSet;
 
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use deadpool_postgres::GenericClient;
 use postgres_from_row::FromRow;
+use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use shared::{Bookmark, TagOperation};
 use tracing::{debug, info};
 use uuid::Uuid;
 
-use super::PgPool;
+use super::{PgPool, ResultExt};
+use crate::bookmark_identity::canonicalize_url_str;
 use crate::error::{Error, Result};
+
+const MAX_FAILURE_REASON_LEN: usize = 2048;
 
 fn normalize_tags(tags: &[String]) -> Vec<String> {
     let mut seen = HashSet::new();
@@ -17,6 +22,42 @@ fn normalize_tags(tags: &[String]) -> Vec<String> {
         .map(|t| t.trim().to_lowercase())
         .filter(|t| !t.is_empty() && seen.insert(t.clone()))
         .collect()
+}
+
+fn status_for_initial_tags(tags: Option<&[String]>) -> AiGenerationStatus {
+    match tags {
+        Some(tags) if !tags.is_empty() => AiGenerationStatus::Done,
+        _ => AiGenerationStatus::Pending,
+    }
+}
+
+fn status_for_initial_summary(summary: Option<&str>) -> AiGenerationStatus {
+    match summary {
+        Some(summary) if !summary.trim().is_empty() => AiGenerationStatus::Done,
+        _ => AiGenerationStatus::Pending,
+    }
+}
+
+fn truncate_fail_reason(fail_reason: &str) -> String {
+    if fail_reason.chars().count() <= MAX_FAILURE_REASON_LEN {
+        return fail_reason.to_string();
+    }
+
+    fail_reason.chars().take(MAX_FAILURE_REASON_LEN).collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, FromSql, ToSql)]
+#[postgres(name = "task_status", rename_all = "snake_case")]
+pub enum AiGenerationStatus {
+    Pending,
+    Done,
+    Fail,
+}
+
+#[derive(Debug, Clone)]
+pub struct BookmarkGenerationCandidate {
+    pub bookmark: Bookmark,
+    pub attempts: i16,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -110,16 +151,17 @@ pub async fn get_by_tag(pool: &PgPool, user_id: Uuid, tag: &str) -> Result<Vec<B
     Ok(results)
 }
 
-pub async fn get_by_url_and_user_id(
+pub async fn get_by_canonical_url_and_user_id(
     pool: &PgPool,
     url: &str,
     user_id: Uuid,
 ) -> Result<Option<Bookmark>> {
-    const SQL: &str = "SELECT * FROM bookmark WHERE url = $1 AND user_id = $2;";
-    debug!(url = %url, user_id = %user_id, "Checking for existing bookmark");
+    const SQL: &str = "SELECT * FROM bookmark WHERE canonical_url = $1 AND user_id = $2;";
+    let canonical_url = canonicalize_url_str(url)?;
+    debug!(url = %url, canonical_url = %canonical_url, user_id = %user_id, "Checking for existing bookmark");
     let client = pool.get().await?;
     let result = client
-        .query_opt(SQL, &[&url, &user_id])
+        .query_opt(SQL, &[&canonical_url, &user_id])
         .await?
         .map(|row| {
             RowBookmark::try_from_row(&row)
@@ -129,9 +171,13 @@ pub async fn get_by_url_and_user_id(
         .transpose()?;
     match &result {
         Some(bookmark) => {
-            debug!(bookmark_id = %bookmark.bookmark_id, url = %url, "Found existing bookmark")
+            debug!(
+                bookmark_id = %bookmark.bookmark_id,
+                canonical_url = %canonical_url,
+                "Found existing bookmark"
+            )
         }
-        None => debug!(url = %url, "No existing bookmark found"),
+        None => debug!(canonical_url = %canonical_url, "No existing bookmark found"),
     }
     Ok(result)
 }
@@ -169,12 +215,12 @@ pub async fn update_tags(
     let (update_tag_sql, tags) = match operation {
         TagOperation::Set(tags) => ("tags=$1", normalize_tags(tags)),
         TagOperation::Append(tags) => (
-            "tags=(SELECT ARRAY(SELECT DISTINCT unnest(array_cat(tags, $1))))",
+            "tags=(SELECT ARRAY(SELECT DISTINCT unnest(array_cat(COALESCE(tags, ARRAY[]::text[]), $1))))",
             normalize_tags(tags),
         ),
     };
     let sql = format!(
-        "UPDATE bookmark SET {update_tag_sql}, updated_at=now() WHERE bookmark_id=$2 AND user_id=$3 RETURNING *;"
+        "UPDATE bookmark SET {update_tag_sql}, tag_status='done', tag_attempts=0, tag_next_attempt_at=now(), tag_fail_reason=NULL, updated_at=now() WHERE bookmark_id=$2 AND user_id=$3 RETURNING *;"
     );
     let client = pool.get().await?;
     let row = client
@@ -194,11 +240,14 @@ pub async fn update_tags(
 }
 
 pub async fn save(pool: &PgPool, bookmark: &Bookmark, text_content: &str) -> Result<Bookmark> {
+    let canonical_url = canonicalize_url_str(&bookmark.url)?;
     const SQL: &str = r#"
     INSERT INTO bookmark
-    (bookmark_id, user_id, url, domain, title, text_content, tags, created_at, updated_at)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now()) RETURNING *;"#;
+    (bookmark_id, user_id, url, canonical_url, domain, title, text_content, tags, summary, summary_status, tag_status, created_at, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now(), now()) RETURNING *;"#;
     let normalized_tags: Option<Vec<String>> = bookmark.tags.as_ref().map(|t| normalize_tags(t));
+    let summary_status = status_for_initial_summary(bookmark.summary.as_deref());
+    let tag_status = status_for_initial_tags(normalized_tags.as_deref());
     let client = pool.get().await?;
     let row = client
         .query_one(
@@ -207,13 +256,20 @@ pub async fn save(pool: &PgPool, bookmark: &Bookmark, text_content: &str) -> Res
                 &bookmark.bookmark_id,
                 &bookmark.user_id,
                 &bookmark.url,
+                &canonical_url,
                 &bookmark.domain,
                 &bookmark.title,
                 &text_content,
                 &normalized_tags,
+                &bookmark.summary,
+                &summary_status,
+                &tag_status,
             ],
         )
-        .await?;
+        .await
+        .on_constraint("bookmark_canonical_url_user_unique", |_| {
+            Error::constraint_violation("duplicate_bookmark", "bookmark already exists for user")
+        })?;
     let result = RowBookmark::try_from_row(&row)
         .map(Bookmark::from)
         .map_err(Error::from)?;
@@ -227,13 +283,107 @@ pub async fn save(pool: &PgPool, bookmark: &Bookmark, text_content: &str) -> Res
     Ok(result)
 }
 
+async fn bookmark_has_canonical_url_column(client: &impl GenericClient) -> Result<bool> {
+    let exists = client
+        .query_one(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'bookmark'
+                  AND column_name = 'canonical_url'
+            );
+            "#,
+            &[],
+        )
+        .await?
+        .get(0);
+    Ok(exists)
+}
+
+pub async fn ensure_canonical_url_support(pool: &PgPool) -> Result<()> {
+    let mut client = pool.get().await?;
+    if !bookmark_has_canonical_url_column(&client).await? {
+        return Ok(());
+    }
+
+    let tx = client.transaction().await?;
+    let rows = tx
+        .query(
+            r#"
+            SELECT bookmark_id, user_id, url
+            FROM bookmark
+            WHERE canonical_url IS NULL
+            ORDER BY created_at ASC;
+            "#,
+            &[],
+        )
+        .await?;
+
+    for row in rows {
+        let bookmark_id: String = row.get("bookmark_id");
+        let user_id: Uuid = row.get("user_id");
+        let url: String = row.get("url");
+        let canonical_url = canonicalize_url_str(&url)?;
+        tx.execute(
+            "UPDATE bookmark SET canonical_url = $1 WHERE bookmark_id = $2 AND user_id = $3",
+            &[&canonical_url, &bookmark_id, &user_id],
+        )
+        .await?;
+    }
+
+    if let Some(row) = tx
+        .query_opt(
+            r#"
+            SELECT user_id, canonical_url, COUNT(*) AS row_count
+            FROM bookmark
+            WHERE canonical_url IS NOT NULL
+            GROUP BY user_id, canonical_url
+            HAVING COUNT(*) > 1
+            LIMIT 1;
+            "#,
+            &[],
+        )
+        .await?
+    {
+        let user_id: Uuid = row.get("user_id");
+        let canonical_url: String = row.get("canonical_url");
+        let row_count: i64 = row.get("row_count");
+        return Err(anyhow!(
+            "bookmark canonical_url collision for user_id={user_id}, canonical_url={canonical_url}, row_count={row_count}"
+        )
+        .into());
+    }
+
+    tx.batch_execute(
+        r#"
+        ALTER TABLE bookmark ALTER COLUMN canonical_url SET NOT NULL;
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'bookmark_canonical_url_user_unique'
+            ) THEN
+                ALTER TABLE bookmark
+                ADD CONSTRAINT bookmark_canonical_url_user_unique UNIQUE (user_id, canonical_url);
+            END IF;
+        END $$;
+        "#,
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
 pub async fn update_summary(
     pool: &PgPool,
     user_id: Uuid,
     bookmark_id: &str,
     summary: &str,
 ) -> Result<Bookmark> {
-    const SQL: &str = "UPDATE bookmark SET summary = $1, updated_at=now() WHERE bookmark_id=$2 AND user_id=$3 RETURNING *;";
+    const SQL: &str = "UPDATE bookmark SET summary = $1, summary_status='done', summary_attempts=0, summary_next_attempt_at=now(), summary_fail_reason=NULL, updated_at=now() WHERE bookmark_id=$2 AND user_id=$3 RETURNING *;";
     let client = pool.get().await?;
     let row = client
         .query_one(SQL, &[&summary, &bookmark_id, &user_id])
@@ -272,23 +422,40 @@ pub async fn get_text_content(
     Ok(result)
 }
 
-pub async fn get_untagged_bookmarks(pool: &PgPool, limit: usize) -> Result<Vec<Bookmark>> {
-    let sql = format!(
-        "SELECT * FROM bookmark WHERE tags IS NULL OR coalesce(array_length(tags, 1), 0) = 0 ORDER BY random() LIMIT {limit};"
-    );
-    debug!(limit = %limit, "Fetching untagged bookmarks");
+pub async fn get_bookmarks_pending_tag_generation(
+    pool: &PgPool,
+    limit: usize,
+    now: DateTime<Utc>,
+) -> Result<Vec<BookmarkGenerationCandidate>> {
+    const SQL: &str = r#"
+        SELECT *
+        FROM bookmark
+        WHERE tag_status = $1
+          AND tag_next_attempt_at <= $2
+          AND (tags IS NULL OR coalesce(array_length(tags, 1), 0) = 0)
+        ORDER BY tag_next_attempt_at ASC, created_at ASC
+        LIMIT $3;
+    "#;
+    debug!(limit = %limit, current_time = %now, "Fetching bookmarks pending tag generation");
     let client = pool.get().await?;
+    let status = AiGenerationStatus::Pending;
     let results = client
-        .query(&sql, &[])
+        .query(SQL, &[&status, &now, &(limit as i64)])
         .await?
         .iter()
         .map(|row| {
-            RowBookmark::try_from_row(row)
+            let bookmark = RowBookmark::try_from_row(row)
                 .map(Bookmark::from)
-                .map_err(Error::from)
+                .map_err(Error::from)?;
+            let attempts: i16 = row.try_get("tag_attempts").map_err(Error::from)?;
+            Ok(BookmarkGenerationCandidate { bookmark, attempts })
         })
         .collect::<Result<Vec<_>>>()?;
-    info!(found_count = %results.len(), limit = %limit, "Found untagged bookmarks");
+    info!(
+        found_count = %results.len(),
+        limit = %limit,
+        "Found bookmarks pending tag generation"
+    );
     Ok(results)
 }
 
@@ -306,24 +473,135 @@ pub async fn delete(pool: &PgPool, user_id: Uuid, bookmark_id: &str) -> Result<b
     }
 }
 
-pub async fn get_bookmarks_without_summary(
+pub async fn get_bookmarks_pending_summary_generation(
     pool: &PgPool,
     limit: usize,
-) -> anyhow::Result<Vec<Bookmark>> {
-    let sql =
-        format!("SELECT * FROM bookmark WHERE summary IS NULL ORDER BY random() LIMIT {limit};");
-    debug!(limit = %limit, "Fetching bookmarks without summaries");
+) -> Result<Vec<BookmarkGenerationCandidate>> {
+    let now = Utc::now();
+    get_bookmarks_pending_summary_generation_at(pool, limit, now).await
+}
+
+pub async fn get_bookmarks_pending_summary_generation_at(
+    pool: &PgPool,
+    limit: usize,
+    now: DateTime<Utc>,
+) -> Result<Vec<BookmarkGenerationCandidate>> {
+    const SQL: &str = r#"
+        SELECT *
+        FROM bookmark
+        WHERE summary_status = $1
+          AND summary_next_attempt_at <= $2
+          AND summary IS NULL
+        ORDER BY summary_next_attempt_at ASC, created_at ASC
+        LIMIT $3;
+    "#;
+    debug!(limit = %limit, current_time = %now, "Fetching bookmarks pending summary generation");
     let client = pool.get().await?;
+    let status = AiGenerationStatus::Pending;
     let results = client
-        .query(&sql, &[])
+        .query(SQL, &[&status, &now, &(limit as i64)])
         .await?
         .iter()
         .map(|row| {
-            RowBookmark::try_from_row(row)
+            let bookmark = RowBookmark::try_from_row(row)
                 .map(Bookmark::from)
-                .map_err(Error::from)
+                .map_err(Error::from)?;
+            let attempts: i16 = row.try_get("summary_attempts").map_err(Error::from)?;
+            Ok(BookmarkGenerationCandidate { bookmark, attempts })
         })
         .collect::<Result<Vec<_>>>()?;
-    info!(found_count = %results.len(), limit = %limit, "Found bookmarks without summaries");
+    info!(
+        found_count = %results.len(),
+        limit = %limit,
+        "Found bookmarks pending summary generation"
+    );
     Ok(results)
+}
+
+pub async fn mark_summary_generation_failure(
+    pool: &PgPool,
+    user_id: Uuid,
+    bookmark_id: &str,
+    status: AiGenerationStatus,
+    attempts: i16,
+    next_attempt_at: DateTime<Utc>,
+    fail_reason: &str,
+) -> Result<()> {
+    const SQL: &str = r#"
+        UPDATE bookmark
+        SET summary_status = $1,
+            summary_attempts = $2,
+            summary_next_attempt_at = $3,
+            summary_fail_reason = $4,
+            updated_at = now()
+        WHERE bookmark_id = $5 AND user_id = $6;
+    "#;
+    let client = pool.get().await?;
+    let fail_reason = truncate_fail_reason(fail_reason);
+    let rows_affected = client
+        .execute(
+            SQL,
+            &[
+                &status,
+                &attempts,
+                &next_attempt_at,
+                &fail_reason,
+                &bookmark_id,
+                &user_id,
+            ],
+        )
+        .await?;
+    info!(
+        bookmark_id = %bookmark_id,
+        user_id = %user_id,
+        attempts = %attempts,
+        status = ?status,
+        rows_affected = %rows_affected,
+        "Recorded summary generation failure"
+    );
+    Ok(())
+}
+
+pub async fn mark_tag_generation_failure(
+    pool: &PgPool,
+    user_id: Uuid,
+    bookmark_id: &str,
+    status: AiGenerationStatus,
+    attempts: i16,
+    next_attempt_at: DateTime<Utc>,
+    fail_reason: &str,
+) -> Result<()> {
+    const SQL: &str = r#"
+        UPDATE bookmark
+        SET tag_status = $1,
+            tag_attempts = $2,
+            tag_next_attempt_at = $3,
+            tag_fail_reason = $4,
+            updated_at = now()
+        WHERE bookmark_id = $5 AND user_id = $6;
+    "#;
+    let client = pool.get().await?;
+    let fail_reason = truncate_fail_reason(fail_reason);
+    let rows_affected = client
+        .execute(
+            SQL,
+            &[
+                &status,
+                &attempts,
+                &next_attempt_at,
+                &fail_reason,
+                &bookmark_id,
+                &user_id,
+            ],
+        )
+        .await?;
+    info!(
+        bookmark_id = %bookmark_id,
+        user_id = %user_id,
+        attempts = %attempts,
+        status = ?status,
+        rows_affected = %rows_affected,
+        "Recorded tag generation failure"
+    );
+    Ok(())
 }

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -38,7 +38,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;";
 
-const SCHEMAS: [(i32, &str); 5] = [
+const SCHEMAS: [(i32, &str); 7] = [
     (
         1,
         include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/schema/1_unified.sql")),
@@ -69,6 +69,20 @@ const SCHEMAS: [(i32, &str); 5] = [
         include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/schema/5_reembed_qwen3.sql"
+        )),
+    ),
+    (
+        6,
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/6_ai_generation_retry_state.sql"
+        )),
+    ),
+    (
+        7,
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/7_bookmark_identity.sql"
         )),
     ),
 ];
@@ -145,6 +159,11 @@ pub async fn run_migrations(pool: &PgPool) -> Result<()> {
     } else {
         info!("Database schema is up to date");
     }
+
+    if get_schema_version(pool).await? >= 7 {
+        bookmark::ensure_canonical_url_support(pool).await?;
+    }
+
     Ok(())
 }
 

--- a/server/src/db/user.rs
+++ b/server/src/db/user.rs
@@ -8,6 +8,10 @@ use uuid::Uuid;
 use super::PgPool;
 use crate::db::{Error, Result, ResultExt};
 
+pub(crate) fn normalize_username(username: &str) -> String {
+    username.trim().to_lowercase()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
     pub user_id: Uuid,
@@ -31,7 +35,8 @@ pub async fn get_by_id(pool: &PgPool, id: &Uuid) -> Result<Option<User>> {
 }
 
 pub async fn get_by_username(pool: &PgPool, username: String) -> Result<Option<User>> {
-    const SQL: &str = r#"SELECT * from "user" WHERE username = $1;"#;
+    const SQL: &str = r#"SELECT * from "user" WHERE LOWER(username) = $1;"#;
+    let username = normalize_username(&username);
     debug!(username = %username, "Fetching user by username");
     let client = pool.get().await?;
     let result = client.query_opt(SQL, &[&username]).await?;
@@ -44,6 +49,7 @@ pub async fn get_by_username(pool: &PgPool, username: String) -> Result<Option<U
 }
 
 pub async fn create(pool: &PgPool, username: String, password_hash: String) -> Result<User> {
+    let username = normalize_username(&username);
     const SQL: &str =
         r#"INSERT INTO "user" (username, password_hash) VALUES ($1, $2) RETURNING "user".*;"#;
     let client = pool.get().await?;

--- a/server/src/endpoints/auth.rs
+++ b/server/src/endpoints/auth.rs
@@ -133,7 +133,8 @@ async fn sign_up(
     debug!(username = %payload.username, "Signup validation passed");
 
     let hashed_password = super::hash_password(payload.password).await?;
-    let try_user = user::create(&app_context.pool, payload.username.clone(), hashed_password).await;
+    let normalized_username = user::normalize_username(&payload.username);
+    let try_user = user::create(&app_context.pool, normalized_username, hashed_password).await;
     match try_user {
         Ok(user) => {
             app_context.auth_rate_limiter.reset(&rate_limit_key);
@@ -183,7 +184,8 @@ async fn sign_in(
     validate_signin(&payload)?;
     debug!(username = %payload.username, "Signin validation passed");
 
-    let maybe_user = user::get_by_username(&app_context.pool, payload.username.clone()).await?;
+    let normalized_username = user::normalize_username(&payload.username);
+    let maybe_user = user::get_by_username(&app_context.pool, normalized_username).await?;
     if let Some(user) = maybe_user {
         debug!(username = %user.username, "User found for signin");
         super::verify_password(payload.password, user.password_hash.clone()).await?;
@@ -228,9 +230,10 @@ async fn sign_in(
 #[cfg(test)]
 mod tests {
     use secrecy::SecretString;
-    use shared::SignUpRequest;
+    use shared::{SignInRequest, SignUpRequest};
 
-    use super::validate_signup;
+    use super::{validate_signin, validate_signup};
+    use crate::db::user;
 
     #[test]
     fn signup_requires_minimum_password_length() {
@@ -241,5 +244,21 @@ mod tests {
         });
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn signup_normalizes_username_before_persistence() {
+        assert_eq!(user::normalize_username(" Alice "), "alice");
+        assert_eq!(user::normalize_username("Bob.Smith"), "bob.smith");
+    }
+
+    #[test]
+    fn signin_allows_trimmed_username_input() {
+        let result = validate_signin(&SignInRequest {
+            username: " alice ".into(),
+            password: SecretString::from("password123"),
+        });
+
+        assert!(result.is_ok());
     }
 }

--- a/server/src/endpoints/rag.rs
+++ b/server/src/endpoints/rag.rs
@@ -1,7 +1,9 @@
 use axum::routing::post;
 use axum::{Extension, Json, Router};
 use axum_macros::debug_handler;
-use shared::{RagHistoryRequest, RagHistoryResponse, RagQueryRequest, RagQueryResponse};
+use shared::{
+    HybridSearchConfig, RagHistoryRequest, RagHistoryResponse, RagQueryRequest, RagQueryResponse,
+};
 use tracing::{info, warn};
 
 use super::Claim;
@@ -16,12 +18,50 @@ pub fn routes() -> Router {
         .route("/history", post(rag_history))
 }
 
+fn validate_weighted_hybrid_config(config: &HybridSearchConfig) -> Result<()> {
+    let vector_weight = config.vector_weight.unwrap_or(0.5);
+    let fts_weight = config.fts_weight.unwrap_or(0.5);
+    let mut errors = Vec::new();
+
+    for (field, value) in [("vector_weight", vector_weight), ("fts_weight", fts_weight)] {
+        if !value.is_finite() {
+            errors.push((field, "must be a finite number"));
+        } else if value < 0.0 {
+            errors.push((field, "must be greater than or equal to 0"));
+        }
+    }
+
+    if errors.is_empty() && vector_weight + fts_weight <= 0.0 {
+        errors.push((
+            "hybrid_search",
+            "vector_weight and fts_weight cannot both be zero",
+        ));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::unprocessable_entity(errors))
+    }
+}
+
+fn validate_rag_query_request(request: &RagQueryRequest) -> Result<()> {
+    let Some(config) = request.hybrid_search.as_ref() else {
+        return Ok(());
+    };
+    if !config.enabled || config.use_rrf.unwrap_or(true) {
+        return Ok(());
+    }
+    validate_weighted_hybrid_config(config)
+}
+
 #[debug_handler]
 async fn rag_query(
     claims: Claim,
     Extension(app_context): Extension<AppContext>,
     Json(request): Json<RagQueryRequest>,
 ) -> Result<Json<RagQueryResponse>> {
+    validate_rag_query_request(&request)?;
     info!(
         user_id = %claims.user_id,
         question = %request.question,
@@ -66,6 +106,70 @@ async fn rag_query(
                 error
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::{HybridSearchConfig, RagQueryRequest};
+
+    use super::validate_rag_query_request;
+
+    #[test]
+    fn weighted_hybrid_rejects_zero_total_weight() {
+        let request = RagQueryRequest {
+            question: "test".into(),
+            max_chunks: None,
+            similarity_threshold: None,
+            max_context_tokens: None,
+            hybrid_search: Some(HybridSearchConfig {
+                enabled: true,
+                use_rrf: Some(false),
+                rrf_k: None,
+                vector_weight: Some(0.0),
+                fts_weight: Some(0.0),
+            }),
+        };
+
+        assert!(validate_rag_query_request(&request).is_err());
+    }
+
+    #[test]
+    fn weighted_hybrid_rejects_negative_weight() {
+        let request = RagQueryRequest {
+            question: "test".into(),
+            max_chunks: None,
+            similarity_threshold: None,
+            max_context_tokens: None,
+            hybrid_search: Some(HybridSearchConfig {
+                enabled: true,
+                use_rrf: Some(false),
+                rrf_k: None,
+                vector_weight: Some(-0.1),
+                fts_weight: Some(1.0),
+            }),
+        };
+
+        assert!(validate_rag_query_request(&request).is_err());
+    }
+
+    #[test]
+    fn weighted_hybrid_accepts_positive_weights() {
+        let request = RagQueryRequest {
+            question: "test".into(),
+            max_chunks: None,
+            similarity_threshold: None,
+            max_context_tokens: None,
+            hybrid_search: Some(HybridSearchConfig {
+                enabled: true,
+                use_rrf: Some(false),
+                rrf_k: None,
+                vector_weight: Some(0.2),
+                fts_weight: Some(0.8),
+            }),
+        };
+
+        assert!(validate_rag_query_request(&request).is_ok());
     }
 }
 

--- a/server/src/endpoints/rag.rs
+++ b/server/src/endpoints/rag.rs
@@ -109,6 +109,40 @@ async fn rag_query(
     }
 }
 
+#[debug_handler]
+async fn rag_history(
+    claims: Claim,
+    Extension(app_context): Extension<AppContext>,
+    Json(request): Json<RagHistoryRequest>,
+) -> Result<Json<RagHistoryResponse>> {
+    info!(
+        user_id = %claims.user_id,
+        limit = request.limit,
+        offset = request.offset,
+        "RAG history request received"
+    );
+
+    match get_rag_history(&app_context.pool, claims.user_id, &request).await {
+        Ok(response) => {
+            info!(
+                user_id = %claims.user_id,
+                sessions_returned = response.sessions.len(),
+                total_count = response.total_count,
+                "RAG history retrieved successfully"
+            );
+            Ok(Json(response))
+        }
+        Err(error) => {
+            warn!(
+                user_id = %claims.user_id,
+                ?error,
+                "RAG history retrieval failed"
+            );
+            Err(error)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use shared::{HybridSearchConfig, RagQueryRequest};
@@ -170,39 +204,5 @@ mod tests {
         };
 
         assert!(validate_rag_query_request(&request).is_ok());
-    }
-}
-
-#[debug_handler]
-async fn rag_history(
-    claims: Claim,
-    Extension(app_context): Extension<AppContext>,
-    Json(request): Json<RagHistoryRequest>,
-) -> Result<Json<RagHistoryResponse>> {
-    info!(
-        user_id = %claims.user_id,
-        limit = request.limit,
-        offset = request.offset,
-        "RAG history request received"
-    );
-
-    match get_rag_history(&app_context.pool, claims.user_id, &request).await {
-        Ok(response) => {
-            info!(
-                user_id = %claims.user_id,
-                sessions_returned = response.sessions.len(),
-                total_count = response.total_count,
-                "RAG history retrieved successfully"
-            );
-            Ok(Json(response))
-        }
-        Err(error) => {
-            warn!(
-                user_id = %claims.user_id,
-                ?error,
-                "RAG history retrieval failed"
-            );
-            Err(error)
-        }
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,6 +9,7 @@ use url::Url;
 use self::db::PgPool;
 
 pub mod auth_rate_limit;
+pub mod bookmark_identity;
 pub mod chrome_client;
 pub mod daemon;
 pub mod db;

--- a/server/src/rag.rs
+++ b/server/src/rag.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use anyhow::{Context, Result};
 use shared::{RagChunkMatch, RagQueryRequest, RagQueryResponse};
 use tracing::{debug, info, warn};
@@ -60,7 +62,11 @@ impl RagEngine {
         }
 
         // Remove duplicates and sort by similarity
-        all_matches.sort_by(|a, b| b.similarity_score.partial_cmp(&a.similarity_score).unwrap());
+        all_matches.sort_by(|a, b| {
+            b.similarity_score
+                .partial_cmp(&a.similarity_score)
+                .unwrap_or(Ordering::Equal)
+        });
         all_matches.dedup_by(|a, b| a.chunk.chunk_id == b.chunk.chunk_id);
 
         // Limit the number of chunks
@@ -403,8 +409,11 @@ impl RagEngine {
         }
 
         // Sort by similarity score (highest first)
-        relevant_matches
-            .sort_by(|a, b| b.similarity_score.partial_cmp(&a.similarity_score).unwrap());
+        relevant_matches.sort_by(|a, b| {
+            b.similarity_score
+                .partial_cmp(&a.similarity_score)
+                .unwrap_or(Ordering::Equal)
+        });
 
         info!(
             total_matches = match_count,

--- a/server/tests/integration_db.rs
+++ b/server/tests/integration_db.rs
@@ -38,6 +38,41 @@ async fn test_db_database_migrations() -> anyhow::Result<()> {
         assert!(exists_check, "Table {table} should exist after migrations");
     }
 
+    let canonical_url_column_exists: bool = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'bookmark'
+                  AND column_name = 'canonical_url'
+            )",
+            &[],
+        )
+        .await
+        .context("Failed to query canonical_url column metadata")?
+        .get(0);
+    assert!(
+        canonical_url_column_exists,
+        "bookmark.canonical_url should exist after migrations"
+    );
+    let canonical_url_constraint_exists: bool = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'bookmark_canonical_url_user_unique'
+            )",
+            &[],
+        )
+        .await
+        .context("Failed to query bookmark canonical URL uniqueness constraint")?
+        .get(0);
+    assert!(
+        canonical_url_constraint_exists,
+        "bookmark canonical URL uniqueness constraint should exist after migrations"
+    );
+
     // Verify schema_version table is populated
     let schema_version: i32 = client
         .query_one("SELECT MAX(version) FROM schema_version", &[])
@@ -127,12 +162,13 @@ async fn test_db_migration_4_backfills_existing_version_3_data() -> anyhow::Resu
 
     client
         .execute(
-            "INSERT INTO bookmark (bookmark_id, user_id, url, domain, title, text_content, tags) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+            "INSERT INTO bookmark (bookmark_id, user_id, url, canonical_url, domain, title, text_content, tags) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
             &[
                 &"bookmark-migration-4",
                 &user_id,
                 &"https://example.com",
+                &"https://example.com/",
                 &"example.com",
                 &"Example",
                 &"Example body",
@@ -202,7 +238,151 @@ async fn test_db_migration_4_backfills_existing_version_3_data() -> anyhow::Resu
         task_tags.into_iter().collect::<BTreeSet<_>>(),
         BTreeSet::from(["ops".to_string()])
     );
-    assert_eq!(schema_version, 5);
+    assert_eq!(schema_version, 7);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_db_migration_7_backfills_bookmark_identity() -> anyhow::Result<()> {
+    let db = TestDatabase::new_empty().await?;
+    let client = db.pool.get().await?;
+
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/1_unified.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 1")?;
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/2_embedding_dimension.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 2")?;
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/3_lowercase_tags.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 3")?;
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/4_trim_tags.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 4")?;
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/5_reembed_qwen3.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 5")?;
+    client
+        .batch_execute(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/schema/6_ai_generation_retry_state.sql"
+        )))
+        .await
+        .context("Failed to apply schema version 6")?;
+
+    client
+        .batch_execute(
+            r#"
+            ALTER TABLE bookmark DROP CONSTRAINT IF EXISTS bookmark_canonical_url_user_unique;
+            ALTER TABLE bookmark DROP COLUMN canonical_url;
+            ALTER TABLE bookmark ADD CONSTRAINT bookmark_url_user_unique UNIQUE (url, user_id);
+            ALTER TABLE bookmark ADD CONSTRAINT bookmark_bookmark_id_key UNIQUE (bookmark_id);
+            "#,
+        )
+        .await
+        .context("Failed to reshape bookmark table to pre-migration-7 state")?;
+
+    client
+        .execute(
+            "INSERT INTO \"user\" (user_id, username, password_hash) VALUES ($1, $2, $3)",
+            &[
+                &uuid::Uuid::new_v4(),
+                &"migration-test-user-7",
+                &"password_hash",
+            ],
+        )
+        .await
+        .context("Failed to insert test user")?;
+
+    let user_id: uuid::Uuid = client
+        .query_one(
+            "SELECT user_id FROM \"user\" WHERE username = $1",
+            &[&"migration-test-user-7"],
+        )
+        .await
+        .context("Failed to fetch test user")?
+        .get(0);
+
+    client
+        .execute(
+            "INSERT INTO bookmark (bookmark_id, user_id, url, domain, title, text_content) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+            &[
+                &"bookmark-migration-7",
+                &user_id,
+                &"https://EXAMPLE.com:443/post?a=1#section",
+                &"example.com",
+                &"Example",
+                &"Example body",
+            ],
+        )
+        .await
+        .context("Failed to insert bookmark before migration 7")?;
+
+    drop(client);
+
+    db::run_migrations(&db.pool)
+        .await
+        .context("Failed to apply pending migrations after schema version 6")?;
+
+    let client = db.pool.get().await?;
+    let canonical_url: String = client
+        .query_one(
+            "SELECT canonical_url FROM bookmark WHERE bookmark_id = $1 AND user_id = $2",
+            &[&"bookmark-migration-7", &user_id],
+        )
+        .await
+        .context("Failed to query canonical_url after migration 7")?
+        .get(0);
+    let has_per_user_canonical_unique: bool = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'bookmark_canonical_url_user_unique'
+            )",
+            &[],
+        )
+        .await
+        .context("Failed to query per-user canonical URL constraint")?
+        .get(0);
+    let has_global_bookmark_id_unique: bool = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'bookmark_bookmark_id_key'
+            )",
+            &[],
+        )
+        .await
+        .context("Failed to query legacy bookmark_id uniqueness constraint")?
+        .get(0);
+
+    assert_eq!(canonical_url, "https://example.com/post?a=1");
+    assert!(has_per_user_canonical_unique);
+    assert!(!has_global_bookmark_id_unique);
 
     Ok(())
 }

--- a/server/tests/integration_db_bookmark.rs
+++ b/server/tests/integration_db_bookmark.rs
@@ -2,9 +2,41 @@
 
 mod common;
 
+use chrono::{Duration, Utc};
 use common::test_db::{create_test_bookmark, create_test_user, TestDatabase};
-use server::db::bookmark;
+use server::db::bookmark::{self, AiGenerationStatus};
 use shared::TagOperation;
+
+async fn get_processing_state(
+    db: &TestDatabase,
+    bookmark_id: &str,
+) -> anyhow::Result<(
+    AiGenerationStatus,
+    i16,
+    Option<String>,
+    AiGenerationStatus,
+    i16,
+    Option<String>,
+)> {
+    let client = db.pool.get().await?;
+    let row = client
+        .query_one(
+            "SELECT summary_status, summary_attempts, summary_fail_reason, tag_status, tag_attempts, tag_fail_reason
+             FROM bookmark
+             WHERE bookmark_id = $1",
+            &[&bookmark_id],
+        )
+        .await?;
+
+    Ok((
+        row.get("summary_status"),
+        row.get("summary_attempts"),
+        row.get("summary_fail_reason"),
+        row.get("tag_status"),
+        row.get("tag_attempts"),
+        row.get("tag_fail_reason"),
+    ))
+}
 
 #[tokio::test]
 async fn test_bookmark_save_and_retrieve() -> anyhow::Result<()> {
@@ -34,8 +66,9 @@ async fn test_bookmark_save_and_retrieve() -> anyhow::Result<()> {
     assert_eq!(saved_bookmark.summary, None);
     assert!(saved_bookmark.created_at <= saved_bookmark.updated_at.unwrap());
 
-    // Test get_by_url_and_user_id
-    let retrieved = bookmark::get_by_url_and_user_id(&db.pool, &bookmark.url, user_id).await?;
+    // Test canonical URL lookup
+    let retrieved =
+        bookmark::get_by_canonical_url_and_user_id(&db.pool, &bookmark.url, user_id).await?;
     assert!(retrieved.is_some());
     let retrieved = retrieved.unwrap();
     assert_eq!(retrieved.bookmark_id, bookmark.bookmark_id);
@@ -155,14 +188,14 @@ async fn test_get_by_tag() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_get_by_url_and_user_id() -> anyhow::Result<()> {
+async fn test_get_by_canonical_url_and_user_id() -> anyhow::Result<()> {
     let db = TestDatabase::new().await?;
     let user1_id = create_test_user(&db).await?;
     let user2_id = create_test_user(&db).await?;
 
     let bookmark1 = create_test_bookmark(
         user1_id,
-        "https://example.com/shared",
+        "https://example.com/shared?a=1",
         "Shared URL",
         "example.com",
         None,
@@ -171,7 +204,7 @@ async fn test_get_by_url_and_user_id() -> anyhow::Result<()> {
 
     let bookmark2 = create_test_bookmark(
         user2_id,
-        "https://example.com/shared",
+        "https://example.com/shared?a=1",
         "Same URL Different User",
         "example.com",
         None,
@@ -179,21 +212,62 @@ async fn test_get_by_url_and_user_id() -> anyhow::Result<()> {
     bookmark::save(&db.pool, &bookmark2, "content2").await?;
 
     // Get bookmark for user1
-    let result1 =
-        bookmark::get_by_url_and_user_id(&db.pool, "https://example.com/shared", user1_id).await?;
+    let result1 = bookmark::get_by_canonical_url_and_user_id(
+        &db.pool,
+        "https://EXAMPLE.com:443/shared?a=1#top",
+        user1_id,
+    )
+    .await?;
     assert!(result1.is_some());
     assert_eq!(result1.unwrap().bookmark_id, bookmark1.bookmark_id);
 
     // Get bookmark for user2
-    let result2 =
-        bookmark::get_by_url_and_user_id(&db.pool, "https://example.com/shared", user2_id).await?;
+    let result2 = bookmark::get_by_canonical_url_and_user_id(
+        &db.pool,
+        "https://example.com/shared?a=1",
+        user2_id,
+    )
+    .await?;
     assert!(result2.is_some());
     assert_eq!(result2.unwrap().bookmark_id, bookmark2.bookmark_id);
 
     // Try to get non-existent URL
     let result3 =
-        bookmark::get_by_url_and_user_id(&db.pool, "https://nonexistent.com", user1_id).await?;
+        bookmark::get_by_canonical_url_and_user_id(&db.pool, "https://nonexistent.com", user1_id)
+            .await?;
     assert!(result3.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_same_bookmark_id_can_exist_for_different_users() -> anyhow::Result<()> {
+    let db = TestDatabase::new().await?;
+    let user1_id = create_test_user(&db).await?;
+    let user2_id = create_test_user(&db).await?;
+
+    let mut bookmark1 = create_test_bookmark(
+        user1_id,
+        "https://example.com/user-1",
+        "User1 Article",
+        "example.com",
+        None,
+    );
+    bookmark1.bookmark_id = "shared-bookmark-id".to_string();
+    let saved1 = bookmark::save(&db.pool, &bookmark1, "content1").await?;
+
+    let mut bookmark2 = create_test_bookmark(
+        user2_id,
+        "https://example.com/user-2",
+        "User2 Article",
+        "example.com",
+        None,
+    );
+    bookmark2.bookmark_id = "shared-bookmark-id".to_string();
+    let saved2 = bookmark::save(&db.pool, &bookmark2, "content2").await?;
+
+    assert_eq!(saved1.bookmark_id, saved2.bookmark_id);
+    assert_ne!(saved1.user_id, saved2.user_id);
 
     Ok(())
 }
@@ -261,6 +335,12 @@ async fn test_update_tags_set() -> anyhow::Result<()> {
         retrieved.unwrap().tags,
         Some(vec!["rust".to_string(), "programming".to_string()])
     );
+
+    let (_, _, _, tag_status, tag_attempts, tag_fail_reason) =
+        get_processing_state(&db, &saved.bookmark_id).await?;
+    assert_eq!(tag_status, AiGenerationStatus::Done);
+    assert_eq!(tag_attempts, 0);
+    assert!(tag_fail_reason.is_none());
 
     Ok(())
 }
@@ -335,6 +415,12 @@ async fn test_update_summary() -> anyhow::Result<()> {
     let retrieved = bookmark::get_with_user_data(&db.pool, user_id, &saved.bookmark_id).await?;
     assert!(retrieved.is_some());
     assert_eq!(retrieved.unwrap().summary, Some(summary_text.to_string()));
+
+    let (summary_status, summary_attempts, summary_fail_reason, _, _, _) =
+        get_processing_state(&db, &saved.bookmark_id).await?;
+    assert_eq!(summary_status, AiGenerationStatus::Done);
+    assert_eq!(summary_attempts, 0);
+    assert!(summary_fail_reason.is_none());
 
     Ok(())
 }
@@ -432,7 +518,7 @@ async fn test_get_tag_count_by_user() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_get_untagged_bookmarks() -> anyhow::Result<()> {
+async fn test_get_bookmarks_pending_tag_generation_respects_backoff() -> anyhow::Result<()> {
     let db = TestDatabase::new().await?;
     let user_id = create_test_user(&db).await?;
 
@@ -454,7 +540,7 @@ async fn test_get_untagged_bookmarks() -> anyhow::Result<()> {
         "example.com",
         Some(vec![]),
     );
-    bookmark::save(&db.pool, &empty_tags_bookmark, "content2").await?;
+    let empty_saved = bookmark::save(&db.pool, &empty_tags_bookmark, "content2").await?;
 
     // Create bookmark with null tags
     let null_tags_bookmark = create_test_bookmark(
@@ -464,27 +550,74 @@ async fn test_get_untagged_bookmarks() -> anyhow::Result<()> {
         "example.com",
         None,
     );
-    bookmark::save(&db.pool, &null_tags_bookmark, "content3").await?;
+    let null_saved = bookmark::save(&db.pool, &null_tags_bookmark, "content3").await?;
 
-    // Get untagged bookmarks (should include empty and null tags)
-    let untagged = bookmark::get_untagged_bookmarks(&db.pool, 10).await?;
+    let now = Utc::now() + Duration::seconds(1);
+    let pending = bookmark::get_bookmarks_pending_tag_generation(&db.pool, 10, now).await?;
+    assert_eq!(pending.len(), 2);
+    let urls: Vec<&str> = pending
+        .iter()
+        .map(|candidate| candidate.bookmark.url.as_str())
+        .collect();
+    assert!(urls.contains(&"https://example.com/empty"));
+    assert!(urls.contains(&"https://example.com/null"));
+    assert!(!urls.contains(&"https://example.com/tagged"));
 
-    assert_eq!(untagged.len(), 2); // empty_tags and null_tags bookmarks
+    let retry_at = now + Duration::minutes(5);
+    bookmark::mark_tag_generation_failure(
+        &db.pool,
+        user_id,
+        &empty_saved.bookmark_id,
+        AiGenerationStatus::Pending,
+        1,
+        retry_at,
+        "temporary failure",
+    )
+    .await?;
 
-    let urls: Vec<&String> = untagged.iter().map(|b| &b.url).collect();
-    assert!(urls.contains(&&"https://example.com/empty".to_string()));
-    assert!(urls.contains(&&"https://example.com/null".to_string()));
-    assert!(!urls.contains(&&"https://example.com/tagged".to_string()));
+    let pending_before_retry =
+        bookmark::get_bookmarks_pending_tag_generation(&db.pool, 10, now).await?;
+    assert_eq!(pending_before_retry.len(), 1);
+    assert_eq!(
+        pending_before_retry[0].bookmark.bookmark_id,
+        null_saved.bookmark_id
+    );
 
-    // Test limit
-    let limited = bookmark::get_untagged_bookmarks(&db.pool, 1).await?;
-    assert_eq!(limited.len(), 1);
+    let pending_after_retry = bookmark::get_bookmarks_pending_tag_generation(
+        &db.pool,
+        10,
+        retry_at + Duration::seconds(1),
+    )
+    .await?;
+    let retried = pending_after_retry
+        .iter()
+        .find(|candidate| candidate.bookmark.bookmark_id == empty_saved.bookmark_id)
+        .expect("bookmark should be retried after backoff");
+    assert_eq!(retried.attempts, 1);
+
+    bookmark::mark_tag_generation_failure(
+        &db.pool,
+        user_id,
+        &empty_saved.bookmark_id,
+        AiGenerationStatus::Fail,
+        5,
+        retry_at,
+        "permanent failure",
+    )
+    .await?;
+
+    let after_terminal_failure =
+        bookmark::get_bookmarks_pending_tag_generation(&db.pool, 10, retry_at + Duration::hours(1))
+            .await?;
+    assert!(after_terminal_failure
+        .iter()
+        .all(|candidate| candidate.bookmark.bookmark_id != empty_saved.bookmark_id));
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_get_bookmarks_without_summary() -> anyhow::Result<()> {
+async fn test_get_bookmarks_pending_summary_generation_respects_backoff() -> anyhow::Result<()> {
     let db = TestDatabase::new().await?;
     let user_id = create_test_user(&db).await?;
 
@@ -513,18 +646,57 @@ async fn test_get_bookmarks_without_summary() -> anyhow::Result<()> {
         "example.com",
         None,
     );
-    bookmark::save(&db.pool, &without_summary, "content2").await?;
+    let pending_summary = bookmark::save(&db.pool, &without_summary, "content2").await?;
 
-    // Get bookmarks without summary
-    let no_summaries = bookmark::get_bookmarks_without_summary(&db.pool, 10).await?;
+    let now = Utc::now() + Duration::seconds(1);
+    let pending = bookmark::get_bookmarks_pending_summary_generation_at(&db.pool, 10, now).await?;
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].bookmark.bookmark_id, pending_summary.bookmark_id);
+    assert_eq!(pending[0].attempts, 0);
 
-    assert_eq!(no_summaries.len(), 1);
-    assert_eq!(no_summaries[0].url, "https://example.com/no-summary");
-    assert!(no_summaries[0].summary.is_none());
+    let retry_at = now + Duration::minutes(15);
+    bookmark::mark_summary_generation_failure(
+        &db.pool,
+        user_id,
+        &pending_summary.bookmark_id,
+        AiGenerationStatus::Pending,
+        1,
+        retry_at,
+        "temporary failure",
+    )
+    .await?;
 
-    // Test limit
-    let limited = bookmark::get_bookmarks_without_summary(&db.pool, 0).await?;
-    assert_eq!(limited.len(), 0);
+    let before_retry =
+        bookmark::get_bookmarks_pending_summary_generation_at(&db.pool, 10, now).await?;
+    assert!(before_retry.is_empty());
+
+    let after_retry = bookmark::get_bookmarks_pending_summary_generation_at(
+        &db.pool,
+        10,
+        retry_at + Duration::seconds(1),
+    )
+    .await?;
+    assert_eq!(after_retry.len(), 1);
+    assert_eq!(after_retry[0].attempts, 1);
+
+    bookmark::mark_summary_generation_failure(
+        &db.pool,
+        user_id,
+        &pending_summary.bookmark_id,
+        AiGenerationStatus::Fail,
+        5,
+        retry_at,
+        "permanent failure",
+    )
+    .await?;
+
+    let after_terminal_failure = bookmark::get_bookmarks_pending_summary_generation_at(
+        &db.pool,
+        10,
+        retry_at + Duration::hours(1),
+    )
+    .await?;
+    assert!(after_terminal_failure.is_empty());
 
     Ok(())
 }
@@ -610,7 +782,7 @@ async fn test_duplicate_url_per_user() -> anyhow::Result<()> {
     let user1_id = create_test_user(&db).await?;
     let user2_id = create_test_user(&db).await?;
 
-    let url = "https://example.com/duplicate";
+    let url = "https://example.com/duplicate?a=1";
 
     // User1 saves URL - should succeed
     let bookmark1 = create_test_bookmark(user1_id, url, "User1 Title", "example.com", None);
@@ -622,12 +794,63 @@ async fn test_duplicate_url_per_user() -> anyhow::Result<()> {
     let saved2 = bookmark::save(&db.pool, &bookmark2, "content2").await?;
     assert_eq!(saved2.url, url);
 
-    // User1 tries to save same URL again - should fail due to unique constraint
-    let bookmark1_duplicate =
-        create_test_bookmark(user1_id, url, "Duplicate Title", "example.com", None);
+    // User1 tries to save the same canonical URL again with a variant raw URL.
+    let bookmark1_duplicate = create_test_bookmark(
+        user1_id,
+        "https://EXAMPLE.com:443/duplicate?a=1#top",
+        "Duplicate Title",
+        "example.com",
+        None,
+    );
     let result = bookmark::save(&db.pool, &bookmark1_duplicate, "duplicate content").await;
 
     assert!(result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_canonical_url_distinguishes_query_scheme_and_port() -> anyhow::Result<()> {
+    let db = TestDatabase::new().await?;
+    let user_id = create_test_user(&db).await?;
+
+    let bookmarks = vec![
+        create_test_bookmark(
+            user_id,
+            "https://example.com/article?a=1",
+            "Query One",
+            "example.com",
+            None,
+        ),
+        create_test_bookmark(
+            user_id,
+            "https://example.com/article?a=2",
+            "Query Two",
+            "example.com",
+            None,
+        ),
+        create_test_bookmark(
+            user_id,
+            "http://example.com/article?a=1",
+            "Http Variant",
+            "example.com",
+            None,
+        ),
+        create_test_bookmark(
+            user_id,
+            "https://example.com:8443/article?a=1",
+            "Port Variant",
+            "example.com",
+            None,
+        ),
+    ];
+
+    for bookmark_to_save in bookmarks {
+        bookmark::save(&db.pool, &bookmark_to_save, "content").await?;
+    }
+
+    let user_bookmarks = bookmark::get_by_user(&db.pool, user_id).await?;
+    assert_eq!(user_bookmarks.len(), 4);
 
     Ok(())
 }

--- a/server/tests/integration_db_user.rs
+++ b/server/tests/integration_db_user.rs
@@ -78,7 +78,7 @@ async fn test_case_insensitive_username_uniqueness() -> anyhow::Result<()> {
     let password_hash1 = "hash1".to_string();
 
     let first_user = user::create(&db.pool, username1.clone(), password_hash1).await?;
-    assert_eq!(first_user.username, username1);
+    assert_eq!(first_user.username, "testuser");
 
     // Try to create user with same username but different case - should fail
     let username2 = "testuser".to_string(); // lowercase version
@@ -93,6 +93,26 @@ async fn test_case_insensitive_username_uniqueness() -> anyhow::Result<()> {
     let username3 = "TESTUSER".to_string();
     let result2 = user::create(&db.pool, username3, "hash3".to_string()).await;
     assert!(result2.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_by_username_is_case_insensitive_and_trimmed() -> anyhow::Result<()> {
+    let db = TestDatabase::new().await?;
+
+    let created_user =
+        user::create(&db.pool, "MixedCaseUser".to_string(), "hash1".to_string()).await?;
+    assert_eq!(created_user.username, "mixedcaseuser");
+
+    let retrieved_upper = user::get_by_username(&db.pool, "MIXEDCASEUSER".to_string()).await?;
+    assert!(retrieved_upper.is_some());
+    assert_eq!(retrieved_upper.unwrap().user_id, created_user.user_id);
+
+    let retrieved_trimmed =
+        user::get_by_username(&db.pool, "  mixedcaseuser  ".to_string()).await?;
+    assert!(retrieved_trimmed.is_some());
+    assert_eq!(retrieved_trimmed.unwrap().user_id, created_user.user_id);
 
     Ok(())
 }

--- a/spa/src/components/composite/bookmark_reader.rs
+++ b/spa/src/components/composite/bookmark_reader.rs
@@ -25,6 +25,16 @@ pub fn bookmark_page(props: &Props) -> Html {
     let tags_as_string = state.clone().join(", ");
     let html_content = use_state(|| None);
     {
+        let state = state.clone();
+        let html_content = html_content.clone();
+        let bookmark_id = props.bookmark.bookmark_id.clone();
+        let bookmark_tags = props.bookmark.tags.clone().unwrap_or_default();
+        use_effect_with(bookmark_id, move |_| {
+            state.set(bookmark_tags.clone());
+            html_content.set(None);
+        });
+    }
+    {
         let html_contentt = html_content.clone();
         let token = token.clone();
         let bookmark_id = props.bookmark.bookmark_id.clone();

--- a/spa/src/pages/home.rs
+++ b/spa/src/pages/home.rs
@@ -554,6 +554,7 @@ pub fn home(props: &Props) -> Html {
         Page::Read { bookmark } => {
             html! {
                 <BookmarkReader
+                    key={bookmark.bookmark_id.clone()}
                     user_session={props.user_session.to_owned()}
                     bookmark={bookmark.to_owned()}
                     on_goback={on_goback}


### PR DESCRIPTION
- normalize usernames consistently across signup, signin, and DB lookup
- reject invalid weighted hybrid RAG configs and avoid NaN sort panics
- reset bookmark reader local state when switching bookmarks
- add retry/backoff state for summary and tag generation workers
- stop AI daemons from hot-looping on permanent failures
- introduce canonical bookmark URLs and per-user uniqueness
- remove global bookmark_id uniqueness and allow cross-user ID reuse
- canonicalize bookmark IDs using full URL identity including scheme/query/port
- backfill canonical_url during migration and fail loudly on collisions
- align base schema with current migrated state
- add regression coverage for auth, RAG, daemon retries, bookmark identity, and migrations