### PR TITLE
feat: add APP_MCP_ALLOWED_HOSTS env var for MCP host header validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,3 +268,15 @@ mcp-cli --url http://localhost:3000/mcp --header "Authorization: Bearer $TOKEN"
 ```
 
 With Claude Desktop / Cline / Cursor-style configs that take a `url`-based streamable HTTP server, set the endpoint to `http://localhost:3000/mcp` and add the `Authorization` header with the JWT obtained from the CLI login.
+
+### Allowed Hosts
+
+The MCP endpoint validates the `Host` header against an allowlist (DNS-rebinding protection from the rmcp crate). By default only `localhost`, `127.0.0.1`, and `::1` are accepted.
+
+When deploying behind a reverse proxy or Kubernetes ingress, set `APP_MCP_ALLOWED_HOSTS` to a comma-separated list of allowed hostnames:
+
+```
+APP_MCP_ALLOWED_HOSTS=bookmark-hub.k8s.dpleb.in,localhost,127.0.0.1
+```
+
+When unset, the rmcp defaults (`localhost`, `127.0.0.1`, `::1`) are used. When set, the configured list **replaces** the defaults — include loopback addresses explicitly if you still need local access.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       AI_TEXT_CHUNK_OVERLAP: "100"
       CHROME_HOST: chrome
       CHROME_PORT: 3001
+      # MCP allowed hosts — set to external hostname(s) when behind a proxy/ingress
+      # APP_MCP_ALLOWED_HOSTS: localhost,127.0.0.1
     volumes:
       - bookmark-hub-data:/data
     healthcheck:

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -55,6 +55,13 @@ pub struct Config {
     #[arg(long, env = "APP_CORS_ALLOW_ORIGIN")]
     pub cors_allow_origin: Option<String>,
 
+    /// Comma-separated list of allowed Host header values for the MCP
+    /// Streamable HTTP endpoint. Defaults to localhost, 127.0.0.1, ::1
+    /// (rmcp built-in defaults). Set to the external hostname(s) when
+    /// deploying behind a reverse proxy or ingress.
+    #[arg(long, env = "APP_MCP_ALLOWED_HOSTS")]
+    pub mcp_allowed_hosts: Option<String>,
+
     #[arg(long, env = "APP_DATA_DIR")]
     pub data_dir: PathBuf,
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -198,7 +198,7 @@ async fn setup_app(
         .nest("/api/v1", endpoints::routers_v1())
         .merge(endpoints::health_check())
         .merge(endpoints::static_content(config))
-        .merge(mcp::router())
+        .merge(mcp::router(config.mcp_allowed_hosts.as_deref()))
         .fallback_service(ServeDir::new(env!("SPA_DIST")))
         .layer(metrics)
         .layer(Extension(app_state))

--- a/server/src/mcp/mod.rs
+++ b/server/src/mcp/mod.rs
@@ -68,12 +68,30 @@ async fn mcp_bearer_auth(
 /// the outer application (see `main.rs`); the auth middleware reads it from
 /// request extensions and the MCP tools read it from the per-request
 /// `Parts.extensions`.
-pub fn router() -> Router {
+///
+/// `mcp_allowed_hosts` is an optional comma-separated list of hostnames
+/// (from `APP_MCP_ALLOWED_HOSTS`). When `None`, the rmcp defaults
+/// (`localhost`, `127.0.0.1`, `::1`) are used. When set, the configured
+/// hosts replace the defaults — include loopback addresses explicitly if
+/// local access is still needed.
+pub fn router(mcp_allowed_hosts: Option<&str>) -> Router {
+    let mut config = StreamableHttpServerConfig::default();
+    if let Some(list) = mcp_allowed_hosts {
+        let hosts: Vec<String> = list
+            .split(',')
+            .map(|s| s.trim().to_owned())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !hosts.is_empty() {
+            config = config.with_allowed_hosts(hosts);
+        }
+    }
+
     let service: TowerStreamableHttpService<BookmarkMcpServer, LocalSessionManager> =
         StreamableHttpService::new(
             || Ok(BookmarkMcpServer::new()),
             LocalSessionManager::default().into(),
-            StreamableHttpServerConfig::default(),
+            config,
         );
 
     Router::new()


### PR DESCRIPTION
## Problem
The MCP endpoint returns `403 Forbidden: Host header is not allowed` when accessed through an external hostname (reverse proxy / Kubernetes ingress).

The rmcp crate's `StreamableHttpServerConfig::default()` only allows `localhost`, `127.0.0.1`, and `::1` as Host header values.

## Solution
Add `APP_MCP_ALLOWED_HOSTS` env var (comma-separated list) that configures the allowed hosts for the MCP Streamable HTTP transport.

- When **unset**: rmcp defaults are used (`localhost`, `127.0.0.1`, `::1`)
- When **set**: the configured hosts **replace** the defaults

### Usage
```
APP_MCP_ALLOWED_HOSTS=bookmark-hub.k8s.dpleb.in,localhost,127.0.0.1
```

## Files changed
- `server/src/lib.rs` — add `mcp_allowed_hosts` field to `Config`
- `server/src/mcp/mod.rs` — `router()` accepts and applies allowed hosts
- `server/src/main.rs` — wire config through to `mcp::router()`
- `README.md` — document the new env var
- `docker-compose.yml` — add commented example